### PR TITLE
fix: liens cassés vers les rôles CentComm dans AdminTools.md

### DIFF
--- a/docs/2_UserInterface/AdminTools/AdminTools.md
+++ b/docs/2_UserInterface/AdminTools/AdminTools.md
@@ -177,7 +177,7 @@ CentComm is a unit above the captain.
 
 For more information, see
 
-| **CenterComp** | ![Central-Command-Officer](HowToPlay/Jobs/Protagonist_roles/Centcom_roles/Central-Command-Officer.md), [Death-Squad.md], [Emergency-Response-Team.md] [Redshield-Officer.md]|
+| **CenterComp** | [Central-Command-Officer](../../3_HowToPlay/Jobs/Protagonist_roles/Centcom_roles/Central-Command-Officer.md), [Death-Squad](../../3_HowToPlay/Jobs/Protagonist_roles/Centcom_roles/Death-Squad.md), [Emergency-Response-Team](../../3_HowToPlay/Jobs/Protagonist_roles/Centcom_roles/Emergency-Response-Team.md), [Redshield-Officer](../../3_HowToPlay/Jobs/Protagonist_roles/Centcom_roles/Redshield-Officer.md) |
 
 #### 2.2d - Event Manager
 ![EventManager](https://i.imgur.com/1PYvGB4.png)** Event Type:**.


### PR DESCRIPTION
## Résumé

- Remplace la syntaxe image (`![alt](...)` pointant vers un `.md`, invalide) par une vraie syntaxe lien pour les 4 rôles CentComm.
- Corrige le chemin vers l'emplacement actuel des pages (`docs/3_HowToPlay/Jobs/Protagonist_roles/Centcom_roles/`, déplacées depuis `HowToPlay/Jobs/...` lors d'un renommage de dossier jamais répercuté sur ce lien).

Closes #326

## Contexte

Découvert en tentant un build Docusaurus propre depuis un checkout neuf (pour conteneuriser le déploiement du wiki) — le build plantait sur `Image ... not found` à cause du premier lien.

## Test plan

- [ ] Build Docusaurus complet sans erreur