### PR TITLE
chore: modernise le Dockerfile (Node 16 EOL -> 20)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 AS build
+FROM node:20 AS build
 WORKDIR /usr/src/app
 COPY package*.json ./
 RUN npm install
@@ -7,7 +7,7 @@ RUN npm run build
 
 # Deployment step
 
-FROM busybox:1.35 as deploy
+FROM busybox:1.36 AS deploy
 
 RUN adduser -D static
 USER static


### PR DESCRIPTION
## Résumé

- `node:16` (EOL depuis septembre 2023) → `node:20`. Aucune contrainte stricte dans `package.json` (`engines.node >= 16.14`), Node 20 reste compatible avec Docusaurus 2.4.3.
- `busybox:1.35` → `1.36`.
- Corrige la casse `as`/`AS` relevée par le linter Docker.

## Test plan

- [x] Build complet (i18n en/ru/de) réussi.
- [x] Conteneur lancé, contenu vérifié (HTTP 200, page d'accueil Docusaurus correcte).