### PR TITLE
feat: rejoint traefik-public, labels de routage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,22 @@
 services:
   unitystation-wiki:
     build: .
+    # Port encore publié pendant la préparation de la bascule Traefik :
+    # Apache en dépend tant que la bascule finale n'a pas eu lieu. Retiré
+    # une fois Apache arrêté (Traefik devient l'unique point d'entrée).
     ports:
       - "4012:3000"
     restart: always
+    networks:
+      - default
+      - traefik-public
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.unitystation-wiki.rule=Host(`unitystation-wiki.unionrolistes.fr`)"
+      - "traefik.http.routers.unitystation-wiki.entrypoints=websecure"
+      - "traefik.http.routers.unitystation-wiki.tls.certresolver=le"
+      - "traefik.http.services.unitystation-wiki.loadbalancer.server.port=3000"
+
+networks:
+  traefik-public:
+    external: true


### PR DESCRIPTION
Prépare la bascule Traefik (remplace Apache comme ingress unique pour les domaines *.unionrolistes.fr). Découverte par labels Docker plutôt qu'un vhost Apache séparé à maintenir.

Le port publié (4012) reste en place tant qu'Apache en a besoin — retiré dans une PR de suivi une fois la bascule finale (Apache arrêté) confirmée.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>