### PR TITLE
perf: fiabiliser et réduire la taille du build (465MB -> 267MB)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+node_modules
+build
+duplicates.txt
+FilesNotFound.txt
+FilesNotFound-processed.txt
+Test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,37 @@
-FROM node:20 AS build
+FROM node:20-alpine AS build
 WORKDIR /usr/src/app
+
+# npm ci (pas npm install) : plus rapide et déterministe, s'appuie sur
+# package-lock.json déjà verrouillé au lieu de re-résoudre les versions.
 COPY package*.json ./
-RUN npm install
+RUN npm ci
+
 COPY . .
-RUN npm run build
+
+# --max-old-space-size sous la RAM réelle du VPS (1 vCPU/2GB, partagé avec
+# 13 autres conteneurs) : force V8 à garbage-collecter plus tôt plutôt que
+# de laisser le kernel OOM-killer intervenir brutalement en pleine
+# compilation webpack.
+RUN NODE_OPTIONS="--max-old-space-size=1024" npm run build
+
+# static/img/ (67MB) est copié intégralement par Docusaurus dans le
+# dossier de sortie de CHAQUE locale (comportement natif de
+# staticDirectories, pas un bug applicatif) : build/img, build/fr/img,
+# build/ru/img, build/de/img sont 4 copies identiques. On ne garde que la
+# copie racine et on remplace les 3 autres par des liens symboliques —
+# busybox httpd les suit nativement (vérifié), le contenu servi est
+# identique, seule la taille de l'image finale change (~268MB -> ~67MB
+# pour les images).
+RUN for l in fr ru de; do \
+      if [ -d "build/$l/img" ]; then \
+        rm -rf "build/$l/img" && ln -s ../img "build/$l/img"; \
+      fi; \
+    done
 
 # Deployment step
+# Ce stage n'est jamais publié (multi-stage) : il ne sert qu'à builder,
+# node:20-alpine réduit juste l'empreinte disque pendant le build (pas
+# d'effet sur l'image finale, déjà minimale via busybox ci-dessous).
 
 FROM busybox:1.36 AS deploy
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -141,7 +141,12 @@ const config = {
   },
   themes: ['@docusaurus/theme-mermaid'],
   plugins: [[require.resolve('docusaurus-lunr-search'), {
-    languages: ['en', 'fr', 'ru', 'de']
+    languages: ['en', 'fr', 'ru', 'de'],
+    // Sans ça, le plugin utilise os.cpus() qui peut renvoyer le nombre de
+    // coeurs du host physique plutot que la limite reelle du conteneur (1
+    // vCPU sur ce VPS) : plusieurs threads se battent alors pour un seul
+    // coeur au lieu d'aider.
+    maxThreads: 1
   }]],
 };
 


### PR DESCRIPTION
## Contexte
Le build (4 locales, Docusaurus) tourne directement sur le VPS de prod (1 vCPU/2GB, partagé avec 13 autres conteneurs) et avait déjà échoué deux fois faute de ressources. Quatre correctifs indépendants, aucun ne touche au contenu.

## Changements
- `npm ci` au lieu de `npm install` : plus rapide et déterministe.
- `.dockerignore` (absent jusqu'ici) : exclut `.git/` (67MB), `node_modules`, fichiers résidus.
- `maxThreads: 1` sur `docusaurus-lunr-search` : le plugin utilise `os.cpus()` par défaut, qui peut renvoyer le nombre de cœurs du host physique plutôt que la limite réelle du conteneur (1 vCPU ici) — plusieurs threads se battaient pour un seul cœur.
- `NODE_OPTIONS=--max-old-space-size=1024` : force V8 à garbage-collecter plus tôt plutôt que de laisser le kernel OOM-killer intervenir brutalement en pleine compilation.
- **Dédup des images dupliquées par locale** : `static/img/` (67MB) est copié intégralement par Docusaurus dans le build de CHAQUE locale (comportement natif de `staticDirectories`, pas un bug applicatif) — `build/fr/img`, `build/ru/img`, `build/de/img` étaient 4 copies identiques. Remplacées par des liens symboliques vers `build/img` (vérifié : busybox httpd les suit nativement, Docker `COPY` préserve les symlinks entre stages).

## Piste explorée et abandonnée
Builder chaque locale séparément (`docusaurus build --locale X`) pour réduire le pic mémoire. Testé directement — `--locale fr --out-dir build` écrase la racine au lieu de nicher sous `build/fr/`, contrairement à un build multi-locale classique. Recomposer correctement l'arborescence est un vrai chantier, pas un réglage.

## Mesures
Taille de l'image : 465MB -> 267MB (-43%)

## Test plan
- [x] Build complet (`--no-cache`, 4 locales) réussi sur le VPS
- [x] Symlinks confirmés dans `build/{fr,ru,de}/img`
- [x] Conteneur démarré réellement : `/`, `/fr/`, `/ru/`, `/de/` répondent 200
- [x] Une image testée via `/fr/img/...` et `/img/...` répond 200 dans les deux cas (symlink suivi correctement)

Closes #332